### PR TITLE
Add Debian/Ubuntu section in INSTALL.md 

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,3 +16,11 @@ qmake
 make
 ```
 `qloud` executable will be in `bin` directory.
+
+## On Debian/Ubuntu
+
+* Install dependencies (`libjack-jackd2-dev` can be exchanged with `libjack-dev` if using jackd1):
+```
+sudo apt install qttools5-dev libqwt5-qt5-dev libjack-jackd2-dev libsndfile1-dev libfftw3-dev
+```
+* Change `-lqwt` to `-lqwt-qt5` in `src/src.pro`.


### PR DESCRIPTION
To compile successfully on Ubuntu (tested on 18.04) you need to change `-lqwt` to `-lqwt-qt5` in src/src.pro.

This is because the qt5 version of qwt has a different name so both can be installed at the same time.

If not changed either the linker cannot find -lqwt, or even worse, if libqwt-dev is installed it will link qloud with the qt4 version and give a segfault on startup.