### PR TITLE
Add install rules for program and desktop icon

### DIFF
--- a/config.pri
+++ b/config.pri
@@ -1,0 +1,4 @@
+isEmpty(PREFIX) {
+    win32:PREFIX = C:/Qloud
+    else:PREFIX = /usr/local
+}

--- a/qloud.pro
+++ b/qloud.pro
@@ -1,6 +1,16 @@
-SUBDIRS += src 
+include(config.pri)
+
+SUBDIRS += src
 CONFIG += warn_on \
  qt \
- thread 
+ thread
 
 TEMPLATE = subdirs
+
+desktop.files = qloud.desktop
+desktop.path = $$PREFIX/share/applications
+
+icon.files = qloud.xpm
+icon.path = $$PREFIX/share/pixmaps
+
+INSTALLS += desktop icon

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,3 +1,5 @@
+include(../config.pri)
+
 SOURCES += main.cpp \
  CapThread.cpp \
  Capture.cpp \
@@ -92,3 +94,6 @@ LIBS += -lsndfile \
 -lqwt
 
 QMAKE_CXXFLAGS += -std=c++11
+
+INSTALLS += target
+target.path = $$PREFIX/bin


### PR DESCRIPTION
This adds some rules for `make install`.

Set `PREFIX` at qmake time. Default is set to `/usr/local`

Usage is like this:
```
qmake PREFIX=/usr
make
make install INSTALL_ROOT=/my/package/root
```